### PR TITLE
Removing binary dependency

### DIFF
--- a/lib/Open/directory.js
+++ b/lib/Open/directory.js
@@ -1,4 +1,3 @@
-var binary = require('binary');
 var PullStream = require('../PullStream');
 var unzip = require('./unzip');
 var Promise = require('bluebird');
@@ -8,6 +7,7 @@ var Buffer = require('../Buffer');
 var path = require('path');
 var Writer = require('fstream').Writer;
 var parseDateTime = require('../parseDateTime');
+var parseBuffer = require('../parseBuffer');
 
 var signature = Buffer.alloc(4);
 signature.writeUInt32LE(0x06054b50,0);
@@ -20,11 +20,11 @@ function getCrxHeader(source) {
     if (signature === 0x34327243) {
       var crxHeader;
       return sourceStream.pull(12).then(function(data) {
-        crxHeader = binary.parse(data)
-          .word32lu('version')
-          .word32lu('pubKeyLength')
-          .word32lu('signatureLength')
-          .vars;
+        crxHeader = parseBuffer.parse(data, [
+          ['version', 4],
+          ['pubKeyLength', 4],
+          ['signatureLength', 4],
+        ]);
       }).then(function() {
         return sourceStream.pull(crxHeader.pubKeyLength +crxHeader.signatureLength);
       }).then(function(data) {
@@ -39,12 +39,12 @@ function getCrxHeader(source) {
 
 // Zip64 File Format Notes: https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
 function getZip64CentralDirectory(source, zip64CDL) {
-  var d64loc = binary.parse(zip64CDL)
-    .word32lu('signature')
-    .word32lu('diskNumber')
-    .word64lu('offsetToStartOfCentralDirectory')
-    .word32lu('numberOfDisks')
-    .vars;
+  var d64loc = parseBuffer.parse(zip64CDL, [
+    ['signature', 4],
+    ['diskNumber', 4],
+    ['offsetToStartOfCentralDirectory', 8],
+    ['numberOfDisks', 4],
+  ]);
 
   if (d64loc.signature != 0x07064b50) {
     throw new Error('invalid zip64 end of central dir locator signature (0x07064b50): 0x' + d64loc.signature.toString(16));
@@ -58,18 +58,18 @@ function getZip64CentralDirectory(source, zip64CDL) {
 
 // Zip64 File Format Notes: https://pkware.cachefly.net/webdocs/casestudies/APPNOTE.TXT
 function parseZip64DirRecord (dir64record) {
-  var vars = binary.parse(dir64record)
-    .word32lu('signature')
-    .word64lu('sizeOfCentralDirectory')
-    .word16lu('version')
-    .word16lu('versionsNeededToExtract')
-    .word32lu('diskNumber')
-    .word32lu('diskStart')
-    .word64lu('numberOfRecordsOnDisk')
-    .word64lu('numberOfRecords')
-    .word64lu('sizeOfCentralDirectory')
-    .word64lu('offsetToStartOfCentralDirectory')
-    .vars;
+  var vars = parseBuffer.parse(dir64record, [
+    ['signature', 4],
+    ['sizeOfCentralDirectory', 8],
+    ['version', 2],
+    ['versionsNeededToExtract', 2],
+    ['diskNumber', 4],
+    ['diskStart', 4],
+    ['numberOfRecordsOnDisk', 8],
+    ['numberOfRecords', 8],
+    ['sizeOfCentralDirectory', 8],
+    ['offsetToStartOfCentralDirectory', 8],
+  ]);
 
   if (vars.signature != 0x06064b50) {
     throw new Error('invalid zip64 end of central dir locator signature (0x06064b50): 0x0' + vars.signature.toString(16));
@@ -107,16 +107,16 @@ module.exports = function centralDirectory(source, options) {
       var data = d.directory;
       startOffset = d.crxHeader && d.crxHeader.size || 0;
 
-      vars = binary.parse(data)
-        .word32lu('signature')
-        .word16lu('diskNumber')
-        .word16lu('diskStart')
-        .word16lu('numberOfRecordsOnDisk')
-        .word16lu('numberOfRecords')
-        .word32lu('sizeOfCentralDirectory')
-        .word32lu('offsetToStartOfCentralDirectory')
-        .word16lu('commentLength')
-        .vars;
+      vars = parseBuffer.parse(data, [
+        ['signature', 4],
+        ['diskNumber', 2],
+        ['diskStart', 2],
+        ['numberOfRecordsOnDisk', 2],
+        ['numberOfRecords', 2],
+        ['sizeOfCentralDirectory', 4],
+        ['offsetToStartOfCentralDirectory', 4],
+        ['commentLength', 2],
+      ]);
 
       // Is this zip file using zip64 format? Use same check as Go:
       // https://github.com/golang/go/blob/master/src/archive/zip/reader.go#L503
@@ -179,25 +179,25 @@ module.exports = function centralDirectory(source, options) {
 
       vars.files = Promise.mapSeries(Array(vars.numberOfRecords),function() {
         return records.pull(46).then(function(data) {    
-          var vars = binary.parse(data)
-            .word32lu('signature')
-            .word16lu('versionMadeBy')
-            .word16lu('versionsNeededToExtract')
-            .word16lu('flags')
-            .word16lu('compressionMethod')
-            .word16lu('lastModifiedTime')
-            .word16lu('lastModifiedDate')
-            .word32lu('crc32')
-            .word32lu('compressedSize')
-            .word32lu('uncompressedSize')
-            .word16lu('fileNameLength')
-            .word16lu('extraFieldLength')
-            .word16lu('fileCommentLength')
-            .word16lu('diskNumber')
-            .word16lu('internalFileAttributes')
-            .word32lu('externalFileAttributes')
-            .word32lu('offsetToLocalFileHeader')
-            .vars;
+          var vars = vars = parseBuffer.parse(data, [
+            ['signature', 4],
+            ['versionMadeBy', 2],
+            ['versionsNeededToExtract', 2],
+            ['flags', 2],
+            ['compressionMethod', 2],
+            ['lastModifiedTime', 2],
+            ['lastModifiedDate', 2],
+            ['crc32', 4],
+            ['compressedSize', 4],
+            ['uncompressedSize', 4],
+            ['fileNameLength', 2],
+            ['extraFieldLength', 2],
+            ['fileCommentLength', 2],
+            ['diskNumber', 2],
+            ['internalFileAttributes', 2],
+            ['externalFileAttributes', 4],
+            ['offsetToLocalFileHeader', 4],
+          ]);
 
         vars.offsetToLocalFileHeader += startOffset;
         vars.lastModifiedDateTime = parseDateTime(vars.lastModifiedDate, vars.lastModifiedTime);

--- a/lib/Open/unzip.js
+++ b/lib/Open/unzip.js
@@ -2,11 +2,11 @@ var Promise = require('bluebird');
 var Decrypt = require('../Decrypt');
 var PullStream = require('../PullStream');
 var Stream = require('stream');
-var binary = require('binary');
 var zlib = require('zlib');
 var parseExtraField = require('../parseExtraField');
 var Buffer = require('../Buffer');
 var parseDateTime = require('../parseDateTime');
+var parseBuffer = require('../parseBuffer');
 
 // Backwards compatibility for node versions < 8
 if (!Stream.Writable || !Stream.Writable.prototype.destroy)
@@ -23,19 +23,19 @@ module.exports = function unzip(source,offset,_password, directoryVars) {
 
   entry.vars = file.pull(30)
     .then(function(data) {
-      var vars = binary.parse(data)
-        .word32lu('signature')
-        .word16lu('versionsNeededToExtract')
-        .word16lu('flags')
-        .word16lu('compressionMethod')
-        .word16lu('lastModifiedTime')
-        .word16lu('lastModifiedDate')
-        .word32lu('crc32')
-        .word32lu('compressedSize')
-        .word32lu('uncompressedSize')
-        .word16lu('fileNameLength')
-        .word16lu('extraFieldLength')
-        .vars;
+      var vars = parseBuffer.parse(data, [
+        ['signature', 4],
+        ['versionsNeededToExtract', 2],
+        ['flags', 2],
+        ['compressionMethod', 2],
+        ['lastModifiedTime', 2],
+        ['lastModifiedDate', 2],
+        ['crc32', 4],
+        ['compressedSize', 4],
+        ['uncompressedSize', 4],
+        ['fileNameLength', 2],
+        ['extraFieldLength', 2],
+      ]);
 
       vars.lastModifiedDateTime = parseDateTime(vars.lastModifiedDate, vars.lastModifiedTime);
 

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -1,7 +1,6 @@
 var util = require('util');
 var zlib = require('zlib');
 var Stream = require('stream');
-var binary = require('binary');
 var Promise = require('bluebird');
 var PullStream = require('./PullStream');
 var NoopStream = require('./NoopStream');
@@ -9,6 +8,7 @@ var BufferStream = require('./BufferStream');
 var parseExtraField = require('./parseExtraField');
 var Buffer = require('./Buffer');
 var parseDateTime = require('./parseDateTime');
+var parseBuffer = require('./parseBuffer');
 
 // Backwards compatibility for node versions < 8
 if (!Stream.Writable || !Stream.Writable.prototype.destroy)
@@ -74,11 +74,11 @@ Parse.prototype._readRecord = function () {
 Parse.prototype._readCrxHeader = function() {
   var self = this;
   return self.pull(12).then(function(data) {
-    self.crxHeader = binary.parse(data)
-      .word32lu('version')
-      .word32lu('pubKeyLength')
-      .word32lu('signatureLength')
-      .vars;
+    self.crxHeader = parseBuffer.parse(data, [
+      ['version', 4],
+      ['pubKeyLength', 4],
+      ['signatureLength', 4],
+    ]);
     return self.pull(self.crxHeader.pubKeyLength + self.crxHeader.signatureLength);
   }).then(function(data) {
     self.crxHeader.publicKey = data.slice(0,self.crxHeader.pubKeyLength);
@@ -91,18 +91,18 @@ Parse.prototype._readCrxHeader = function() {
 Parse.prototype._readFile = function () {
   var self = this;
   return self.pull(26).then(function(data) {
-    var vars = binary.parse(data)
-      .word16lu('versionsNeededToExtract')
-      .word16lu('flags')
-      .word16lu('compressionMethod')
-      .word16lu('lastModifiedTime')
-      .word16lu('lastModifiedDate')
-      .word32lu('crc32')
-      .word32lu('compressedSize')
-      .word32lu('uncompressedSize')
-      .word16lu('fileNameLength')
-      .word16lu('extraFieldLength')
-      .vars;
+    var vars = parseBuffer.parse(data, [
+      ['versionsNeededToExtract', 2],
+      ['flags', 2],
+      ['compressionMethod', 2],
+      ['lastModifiedTime', 2],
+      ['lastModifiedDate', 2],
+      ['crc32', 4],
+      ['compressedSize', 4],
+      ['uncompressedSize', 4],
+      ['fileNameLength', 2],
+      ['extraFieldLength', 2],
+    ]);
 
     vars.lastModifiedDateTime = parseDateTime(vars.lastModifiedDate, vars.lastModifiedTime);
 
@@ -205,12 +205,12 @@ Parse.prototype._readFile = function () {
 Parse.prototype._processDataDescriptor = function (entry) {
   var self = this;
   return self.pull(16).then(function(data) {
-    var vars = binary.parse(data)
-      .word32lu('dataDescriptorSignature')
-      .word32lu('crc32')
-      .word32lu('compressedSize')
-      .word32lu('uncompressedSize')
-      .vars;
+    var vars = parseBuffer.parse(data, [
+      ['dataDescriptorSignature', 4],
+      ['crc32', 4],
+      ['compressedSize', 4],
+      ['uncompressedSize', 4],
+    ]);
 
     entry.size = vars.uncompressedSize;
     return self._readRecord();
@@ -220,25 +220,24 @@ Parse.prototype._processDataDescriptor = function (entry) {
 Parse.prototype._readCentralDirectoryFileHeader = function () {
   var self = this;
   return self.pull(42).then(function(data) {
-
-    var vars = binary.parse(data)
-      .word16lu('versionMadeBy')
-      .word16lu('versionsNeededToExtract')
-      .word16lu('flags')
-      .word16lu('compressionMethod')
-      .word16lu('lastModifiedTime')
-      .word16lu('lastModifiedDate')
-      .word32lu('crc32')
-      .word32lu('compressedSize')
-      .word32lu('uncompressedSize')
-      .word16lu('fileNameLength')
-      .word16lu('extraFieldLength')
-      .word16lu('fileCommentLength')
-      .word16lu('diskNumber')
-      .word16lu('internalFileAttributes')
-      .word32lu('externalFileAttributes')
-      .word32lu('offsetToLocalFileHeader')
-      .vars;
+    var vars = parseBuffer.parse(data, [
+      ['versionMadeBy', 2],
+      ['versionsNeededToExtract', 2],
+      ['flags', 2],
+      ['compressionMethod', 2],
+      ['lastModifiedTime', 2],
+      ['lastModifiedDate', 2],
+      ['crc32', 4],
+      ['compressedSize', 4],
+      ['uncompressedSize', 4],
+      ['fileNameLength', 2],
+      ['extraFieldLength', 2],
+      ['fileCommentLength', 2],
+      ['diskNumber', 2],
+      ['internalFileAttributes', 2],
+      ['externalFileAttributes', 4],
+      ['offsetToLocalFileHeader', 4],
+    ]);
 
     return self.pull(vars.fileNameLength).then(function(fileName) {
       vars.fileName = fileName.toString('utf8');
@@ -257,15 +256,15 @@ Parse.prototype._readEndOfCentralDirectoryRecord = function() {
   var self = this;
   return self.pull(18).then(function(data) {
 
-    var vars = binary.parse(data)
-      .word16lu('diskNumber')
-      .word16lu('diskStart')
-      .word16lu('numberOfRecordsOnDisk')
-      .word16lu('numberOfRecords')
-      .word32lu('sizeOfCentralDirectory')
-      .word32lu('offsetToStartOfCentralDirectory')
-      .word16lu('commentLength')
-      .vars;
+    var vars = parseBuffer.parse(data, [
+      ['diskNumber', 2],
+      ['diskStart', 2],
+      ['numberOfRecordsOnDisk', 2],
+      ['numberOfRecords', 2],
+      ['sizeOfCentralDirectory', 4],
+      ['offsetToStartOfCentralDirectory', 4],
+      ['commentLength', 2],
+    ]);
 
     return self.pull(vars.commentLength).then(function(comment) {
       comment = comment.toString('utf8');

--- a/lib/parseBuffer.js
+++ b/lib/parseBuffer.js
@@ -1,0 +1,55 @@
+const parseUIntLE = function(buffer, offset, size) {
+  var result;
+  switch(size) {
+    case 1:
+      result = buffer.readUInt8(offset);
+      break;
+    case 2:
+      result = buffer.readUInt16LE(offset);
+      break;
+    case 4:
+      result = buffer.readUInt32LE(offset);
+      break;
+    case 8:
+      result = Number(buffer.readBigUInt64LE(offset));
+      break;
+    default:
+     throw new Error('Unsupported UInt LE size!');
+  }
+  return result;
+}
+
+/**
+ * Parses sequential unsigned little endian numbers from the head of the passed buffer according to
+ * the specified format passed.  If the buffer is not large enough to satisfy the full format,
+ * null values will be assigned to the remaining keys.
+ * @param {*} buffer The buffer to sequentially extract numbers from.
+ * @param {*} format Expected format to follow when extrcting values from the buffer.  A list of list entries
+ * with the following structure:
+ * [
+ *   [
+ *     <key>,  // Name of the key to assign the extracted number to.
+ *     <size>  // The size in bytes of the number to extract. possible values are 1, 2, 4, 8.
+ *   ],
+ *   ...
+ * ]
+ * @returns An object with keys set to their associated extracted values.
+ */
+const parse = function(buffer, format) {
+  var result = {}
+  var offset = 0;
+  for(const [key, size] of format) {
+    if(buffer.length >= offset + size) {
+      result[key] = parseUIntLE(buffer, offset, size);
+    }
+    else {
+      result[key] = null;
+    }
+    offset += size;
+  }
+  return result;
+}
+
+module.exports = {
+  parse
+}

--- a/lib/parseExtraField.js
+++ b/lib/parseExtraField.js
@@ -1,17 +1,17 @@
-var binary = require('binary');
+var parseBuffer = require('./parseBuffer');
 
 module.exports = function(extraField, vars) {
   var extra;
   // Find the ZIP64 header, if present.
   while(!extra && extraField && extraField.length) {
-    var candidateExtra = binary.parse(extraField)
-      .word16lu('signature')
-      .word16lu('partsize')
-      .word64lu('uncompressedSize')
-      .word64lu('compressedSize')
-      .word64lu('offset')
-      .word64lu('disknum')
-      .vars;
+    var candidateExtra = parseBuffer.parse(extraField, [
+      ['signature', 2],
+      ['partsize', 2],
+      ['uncompressedSize', 8],
+      ['compressedSize', 8],
+      ['offset', 8],
+      ['disknum', 8],
+    ]);
 
     if(candidateExtra.signature === 0x0001) {
       extra = candidateExtra;

--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
   "license": "MIT",
   "dependencies": {
     "big-integer": "^1.6.17",
-    "binary": "~0.3.0",
     "bluebird": "~3.4.1",
     "buffer-indexof-polyfill": "~1.0.0",
     "duplexer2": "~0.1.4",

--- a/test/parseBuffer.js
+++ b/test/parseBuffer.js
@@ -1,0 +1,70 @@
+'use strict';
+
+var test = require('tap').test;
+var parseBuffer = require('../lib/parseBuffer');
+
+const buf = Buffer.from([
+  0x62, 
+  0x75, 
+  0x66, 
+  0x68, 
+  0x65, 
+  0x72, 
+  0xFF, 
+  0xAE,
+  0x00,
+  0x11,
+  0x99,
+  0xD7,
+  0x7B,
+  0x13,
+  0x35
+]);
+
+test(`parse little endian values for increasing byte size`, function (t) {
+  const result = parseBuffer.parse(buf, [
+    ['key1', 1],
+    ['key2', 2],
+    ['key3', 4],
+    ['key4', 8],
+  ]);
+  t.same(result, {
+    key1: 98,
+    key2: 26229,
+    key3: 4285687144,
+    key4: 3824536674483896300
+  });
+  t.end();
+})
+
+test(`parse little endian values for decreasing byte size`, function (t) {
+  const result = parseBuffer.parse(buf, [
+    ['key1', 8],
+    ['key2', 4],
+    ['key3', 2],
+    ['key4', 1],
+  ]);
+  t.same(result, {
+    key1: 12609923261529487000,
+    key2: 3617132800,
+    key3: 4987,
+    key4: 53
+  });
+  t.end();
+})
+
+test(`parse little endian values with null keys due to small buffer`, function (t) {
+  const result = parseBuffer.parse(buf, [
+    ['key1', 8],
+    ['key2', 8],
+    ['key3', 8],
+    ['key4', 8],
+  ]);
+  t.same(result, {
+    key1: 12609923261529487000,
+    key2: null,
+    key3: null,
+    key4: null
+  });
+  t.end();
+})


### PR DESCRIPTION
Removing dependency on the 'binary' package and using node's built-in buffer module to perform unsigned LE number parsing.

testing:
npm install
npm test 